### PR TITLE
Resolves #17 - Add label for draft PRs

### DIFF
--- a/src/components/PullRequests/PullRequest.js
+++ b/src/components/PullRequests/PullRequest.js
@@ -6,6 +6,7 @@ import { Labels } from './Labels';
 import { useConfig } from '../ConfigController/ConfigController';
 import { BuildStatus } from './BuildStatus';
 import { Reviews } from './Reviews';
+import { Label } from './Label';
 
 export const PullRequest = ({ pullRequest }) => {
   const styles = useStyles();
@@ -38,6 +39,8 @@ export const PullRequest = ({ pullRequest }) => {
                 {pullRequest.repository.nameWithOwner}
               </p>
             </div>
+
+            {pullRequest.isDraft && <Label label={{name: 'draft', color: 'CBD5E0'}}></Label>}
 
             <Labels
               labels={pullRequest.labels.nodes}

--- a/src/hooks/queries/usePullRequests.js
+++ b/src/hooks/queries/usePullRequests.js
@@ -11,6 +11,7 @@ const GET_PULL_REQUESTS = gql`
           createdAt
           updatedAt
           permalink
+          isDraft
           baseRefName
           headRefName
           author {


### PR DESCRIPTION
Adds a 'draft' label if the PR is a draft.

![image](https://user-images.githubusercontent.com/2374192/85473499-3d421f00-b5ab-11ea-89c9-9b2efc0049d4.png)
